### PR TITLE
Bot more likely to answer if message contains '?'.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -294,7 +294,9 @@ console.log(props.match.input);
 
     //#region markov
     bot.on('*', (msg) => {
-        if (msg.reply_to_message && msg.reply_to_message.from.username === settings.bot_handle && Math.random() < 0.5) {
+        if (msg.reply_to_message
+                && msg.reply_to_message.from.username === settings.bot_handle
+                && (msg.text.includes('?') || Math.random() < 0.4)) {
             return msg.reply.text(markov.generateMessage(), { asReply: true });
         }
     });


### PR DESCRIPTION
Make bot always answer if message tagging it contains a '?'. In return reduce general probability of answering a little bit. 