### PR TITLE
Chat clusters

### DIFF
--- a/src/dbhelper.js
+++ b/src/dbhelper.js
@@ -5,6 +5,8 @@ class DbHelper {
         this.filename = filename;
         this.quotes = { _id: 'quotes' };
         this.users = { _id: 'users' };
+        this.clusters = { _id: 'clusters' };
+        this.chats = { _id: 'chats' };
     }
 
     load(callback) {
@@ -27,13 +29,18 @@ class DbHelper {
         });
     }
 
-    saveQuote(quoteId, text, date, userId) {
-        if (!this.quotes.hasOwnProperty(quoteId)) {
+    saveQuote(chatId, msgId, text, date, userId) {
+        const msgIdStr = msgId.toString(36);
+        const chatIdStr = Math.abs(chatId).toString(36);
+        const quoteId = (2 * msgIdStr.length + (chatIdStr < 0)).toString(36) + msgIdStr + chatIdStr;
+        const oldQuoteId = msgId;
+        if (!this.quotes.hasOwnProperty(quoteId) && !this.quotes.hasOwnProperty(oldQuoteId)) {
             this.quotes[quoteId] = {
                 id: quoteId,
                 text: text,
                 date: date,
-                user: userId
+                user: userId,
+                chatId: chatId,  // might not exist on older quotes
             };
 
             if (this.users[userId])
@@ -90,12 +97,54 @@ class DbHelper {
         }
     }
 
+    getChatCluster(chatId) {
+        const clusterId = this.chats[chatId] && this.chats[chatId].cluster;
+        return clusterId || `chat:${chatId}`;
+    }
+
+    resetChatCluster(chatId) {
+        if (!this.chats[chatId]) return;
+        const clusterId = this.chats[chatId].cluster;
+        delete this.chats[chatId].cluster;
+        this.clusters[clusterId] = this.clusters[clusterId].filter(a => a !== chatId);
+    }
+
+    setChatCluster(chatId, clusterId) {
+        if (!clusterId.startsWith(`cluster:`)) throw new Error(`Cluster name must start with 'cluster:'!`);
+        this.resetChatCluster(chatId);
+
+        if (!this.clusters[clusterId]) this.clusters[clusterId] = [];
+        this.clusters[clusterId].push(chatId);
+        this.updateClusterInDB(clusterId);
+        
+        if (!this.chats[chatId]) this.chats[chatId] = {};
+        this.chats[chatId].cluster = clusterId;
+        this.updateClusterInDB(chatId);
+    }
+
+    getAllChatsOfCluster(clusterId) {
+        if (clusterId.startsWith(`chat:`)) {
+            return [Number(clusterId.substr(5))];
+        } else if (clusterId.startsWith(`cluster:`)) {
+            return this.clusters[clusterId];
+        }
+        throw new Error(`Unknown cluster ID ${clusterId}!`);
+    }
+
     updateUserInDB(userId) {
         this.updateInDB('users', this.users, userId);
     }
 
     updateQuoteInDB(quoteId) {
         this.updateInDB('quotes', this.quotes, quoteId);
+    }
+
+    updateClusterInDB(clusterId) {
+        this.updateInDB('clusters', this.clusters, clusterId);
+    }
+
+    updateChatInDB(chatId) {
+        this.updateInDB('chats', this.chats, chatId);
     }
 
     updateInDB(_id, container, objId) {

--- a/src/dbhelper.js
+++ b/src/dbhelper.js
@@ -29,7 +29,7 @@ class DbHelper {
         });
     }
 
-    saveQuote(chatId, msgId, text, date, userId) {
+    saveQuote(chatId, msgId, text, date, userId, quoterId) {
         const msgIdStr = msgId.toString(36);
         const chatIdStr = Math.abs(chatId).toString(36);
         const quoteId = (2 * msgIdStr.length + (chatIdStr < 0)).toString(36) + msgIdStr + chatIdStr;
@@ -40,7 +40,8 @@ class DbHelper {
                 text: text,
                 date: date,
                 user: userId,
-                chatId: chatId,  // might not exist on older quotes
+                chatId: chatId,         // might not exist on older quotes
+                quoterId: quoterId,     // might not exist on older quotes
             };
 
             if (this.users[userId])

--- a/src/main.js
+++ b/src/main.js
@@ -444,9 +444,9 @@ function getQuotesByDate() {
     return quotes;
 }
 
-function saveQuote(quote) {
+function saveQuote(quote, quoter) {
     dbhelper.checkOrCreateUser(quote.from.id, quote.from.username, quote.from.first_name);
-    return dbhelper.saveQuote(quote.chat.id, quote.message_id, quote.text, quote.date * 1000, quote.from.id);
+    return dbhelper.saveQuote(quote.chat.id, quote.message_id, quote.text, quote.date * 1000, quote.from.id, quoter.id);
 }
 
 function getHelpText(admin) {

--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,7 @@ async function main() {
         else if (!msg.reply_to_message.text)
             return bot.sendMessage(msg.chat.id, "I can't save non-text messages.",
                 { replyToMessage: msg.reply_to_message.message_id });
-        else if (saveQuote(msg.reply_to_message))
+        else if (saveQuote(msg.reply_to_message, msg.from))
             return bot.sendMessage(msg.chat.id, `Thanks ${getUserDisplay(msg.from)}, quote saved.`,
                 { replyToMessage: msg.reply_to_message.message_id });
         else


### PR DESCRIPTION
Currently, all quotes are global and public. This means that communities will see each others' quotes, resulting in a lot of spam in `/list`, making it almost completely useless. This is likely not desirable, as communities would probably like to only see quotes of their own chats.

A naïve solution is to split up the `/list` command for each chat. However, some communities might have multiple chats which are connected, and they would like to see all the quotes unified. In order to solve this, we need a way to cluster chats together.

Using the `/setcluster` command, (bot) admins can set a chat's cluster; inside a chat, they will be able to see quotes from all other chats in the same cluster. If the command is not used, the chat is simply in a cluster with itself. Once set-up correctly, `/list` displays only quotes from the same cluster. All messages quoted before this update will be added to the `cluster:original` cluster. (They will no longer be visible in any other chats.)

Because users might be interested in a list of their own quotes across all chats (even those they are not in), they can do `/list` inside a private chat with the bot to see a list of their own quotes (alongside all quotes in the private chat's cluster - which is usually none).

Note that the bot is not yet ready for expansion (world domination? :oo). Many actions run in linear time of the total number of quotes (across all clusters) and the database isn't particularly scalable, so additional work needs to be done if the number of quotes grows further (beyond 10k assuming bad actors).

Currently, only bot (not chat) admins can add/remove groups from clusters. This means that communities need to contact a bot admin to add/remove their group from a cluster. In the future, we should change that, and add a way for non-administrative users to create their own clusters which (only) they can administrate.

Also fixes a few minor bugs.